### PR TITLE
Center chunk and set default goxel color

### DIFF
--- a/gaiku-3d/src/bakers/voxel/mod.rs
+++ b/gaiku-3d/src/bakers/voxel/mod.rs
@@ -157,12 +157,17 @@ impl Baker for VoxelBaker {
 
         let mut all_verts: Vec<&VertexData> = vertices.values().flatten().collect();
         all_verts.sort_by_key(|k| k.index);
+        let center: Vector3<f32> = Vector3 {
+            x: (x_limit as f32) / 2.,
+            y: (y_limit as f32) / 2.,
+            z: (z_limit as f32) / 2.,
+        };
         let vertices: Vec<Vector3<f32>> = all_verts
             .iter()
             .map(|v| Vector3 {
-                x: v.position.x as f32 - 0.5,
-                y: v.position.y as f32 - 0.5,
-                z: v.position.z as f32 - 0.5,
+                x: v.position.x as f32 - center.x,
+                y: v.position.y as f32 - center.y,
+                z: v.position.z as f32 - center.z,
             })
             .collect();
         let normals: Vec<Vector3<f32>> = all_verts

--- a/gaiku-common/src/data/chunk.rs
+++ b/gaiku-common/src/data/chunk.rs
@@ -59,7 +59,7 @@ impl Chunk {
     pub fn get_color(&self, x: usize, y: usize, z: usize) -> Option<Vector4<u8>> {
         let index = self.index(x, y, z);
         if let Some(color) = self.colors.get(index) {
-            Some(color.clone())
+            Some(*color)
         } else {
             None
         }

--- a/gaiku-common/src/data/chunk.rs
+++ b/gaiku-common/src/data/chunk.rs
@@ -70,12 +70,16 @@ impl Chunk {
     }
 
     pub fn set(&mut self, x: usize, y: usize, z: usize, value: u8) {
-        let index = self.index(x, y, z);
-        self.values[index] = value;
+        if value != 0 {
+            self.set_with_color(x, y, z, value, [0, 0, 0, 1].into());
+        } else {
+            self.set_with_color(x, y, z, value, [0, 0, 0, 0].into());
+        }
     }
 
-    pub fn set_color(&mut self, x: usize, y: usize, z: usize, color: Vector4<u8>) {
+    pub fn set_with_color(&mut self, x: usize, y: usize, z: usize, value: u8, color: Vector4<u8>) {
         let index = self.index(x, y, z);
+        self.values[index] = value;
         self.colors[index] = color;
     }
 

--- a/gaiku-common/src/data/chunk.rs
+++ b/gaiku-common/src/data/chunk.rs
@@ -71,7 +71,12 @@ impl Chunk {
 
     pub fn set(&mut self, x: usize, y: usize, z: usize, value: u8) {
         if value != 0 {
-            self.set_with_color(x, y, z, value, [0, 0, 0, 1].into());
+          let color: Vector4<u8> = if self.get_color(x, y, z).unwrap_or([0, 0, 0, 0].into())[3] == 0 {
+                   [1, 1, 1, 1].into()
+          } else {
+                   self.get_color(x, y, z).unwrap()
+          }
+          self.set_with_color(x, y, z, value,  color);
         } else {
             self.set_with_color(x, y, z, value, [0, 0, 0, 0].into());
         }

--- a/gaiku-common/src/data/mesh.rs
+++ b/gaiku-common/src/data/mesh.rs
@@ -15,6 +15,17 @@ pub struct Mesh {
     pub tangents: Vec<Vector4<f32>>,
 }
 
+pub enum Corner {
+    TopLeftFront,
+    TopLeftBack,
+    TopRightFront,
+    TopRightBack,
+    BottomLeftFront,
+    BottomLeftBack,
+    BottomRightFront,
+    BottomRightBack,
+}
+
 impl Mesh {
     /// This will generate a texture from the
     /// mesh vertex colors and update the UV map
@@ -89,5 +100,50 @@ impl Mesh {
         }
         // Return the texture
         return result;
+    }
+
+    pub fn get_corner(&self, corner: Corner) -> Vector3<f32> {
+        match corner {
+            Corner::TopLeftFront => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::min),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::max),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::max),
+            },
+            Corner::TopLeftBack => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::min),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::max),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::min),
+            },
+            Corner::TopRightFront => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::max),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::max),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::max),
+            },
+            Corner::TopRightBack => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::max),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::max),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::min),
+            },
+            Corner::BottomLeftFront => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::min),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::min),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::max),
+            },
+            Corner::BottomLeftBack => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::min),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::min),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::min),
+            },
+            Corner::BottomRightFront => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::max),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::min),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::max),
+            },
+            Corner::BottomRightBack => Vector3 {
+                x: self.vertices.iter().map(|i| i.x).fold(f32::NAN, f32::max),
+                y: self.vertices.iter().map(|i| i.y).fold(f32::NAN, f32::min),
+                z: self.vertices.iter().map(|i| i.z).fold(f32::NAN, f32::min),
+            },
+        }
     }
 }

--- a/gaiku-common/src/data/mod.rs
+++ b/gaiku-common/src/data/mod.rs
@@ -1,4 +1,7 @@
 mod chunk;
 mod mesh;
 
-pub use self::{chunk::Chunk, mesh::Mesh};
+pub use self::{
+    chunk::Chunk,
+    mesh::{Corner, Mesh},
+};

--- a/gaiku-common/src/lib.rs
+++ b/gaiku-common/src/lib.rs
@@ -16,7 +16,10 @@ mod data;
 mod tree;
 
 pub use crate::tree::{Boundary, Octree};
-pub use crate::{data::Chunk, data::Mesh};
+pub use crate::{
+    data::Chunk,
+    data::{Corner, Mesh},
+};
 
 pub trait Baker {
     fn bake(chunk: &Chunk) -> Option<Mesh>;


### PR DESCRIPTION
This PR centers the chunks on the zero coordinate during baking (voxel only because marching cubs is broken and I don't really get how it works)

It also adds the set_with_color method discussed in #9 

closes #9