### PR TITLE
Use usize for vertex index

### DIFF
--- a/gaiku-3d/src/bakers/voxel.rs
+++ b/gaiku-3d/src/bakers/voxel.rs
@@ -12,7 +12,7 @@ struct VertexData {
   position: Vector3<usize>,
   normal: Vector3<i8>,
   color: Vector4<u8>,
-  index: u16,
+  index: usize,
 }
 
 impl VertexData {
@@ -216,7 +216,7 @@ fn get_or_insert<'a>(
     },
     normal,
     color,
-    index: next_index as u16,
+    index: next_index,
   };
   let verts = &mut cache.entry(position).or_insert_with(Vec::new);
   verts.push(new_vert);
@@ -225,7 +225,7 @@ fn get_or_insert<'a>(
 
 /// Create the face and insert the vertexes into the cache
 fn create_face(
-  indices: &mut Vec<u16>,
+  indices: &mut Vec<usize>,
   cache: &mut HashMap<(usize, usize, usize), Vec<VertexData>>,
   p1: (usize, usize, usize),
   p2: (usize, usize, usize),

--- a/gaiku-common/src/data/mesh.rs
+++ b/gaiku-common/src/data/mesh.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 
 #[derive(Clone, Debug)]
 pub struct Mesh {
-  pub indices: Vec<u16>,
+  pub indices: Vec<usize>,
   pub vertices: Vec<Vector3<f32>>,
   pub normals: Vec<Vector3<f32>>,
   pub colors: Vec<Vector4<u8>>,
@@ -19,7 +19,7 @@ impl Mesh {
   /// the RGBA color
   #[allow(clippy::many_single_char_names)]
   pub fn generate_texture(&mut self, width: usize, height: usize) -> Vec<u32> {
-    let mut colors: HashMap<(u8, u8, u8, u8), Vec<[u16; 3]>> = HashMap::new();
+    let mut colors: HashMap<(u8, u8, u8, u8), Vec<[usize; 3]>> = HashMap::new();
     self.uv = vec![Vector2 { x: 0., y: 0. }; self.vertices.len()];
 
     // Check the color of every face

--- a/gaiku-common/src/lib.rs
+++ b/gaiku-common/src/lib.rs
@@ -14,10 +14,10 @@ pub trait Baker {
   fn bake(chunk: &Chunk) -> Option<Mesh>;
 
   // TODO: Creating a string key from the coordinates is not the best solution, enhance this
-  fn index(vertices: &mut HashMap<String, (Vector3<f32>, u16)>, vertex: Vector3<f32>) -> u16 {
+  fn index(vertices: &mut HashMap<String, (Vector3<f32>, usize)>, vertex: Vector3<f32>) -> usize {
     let index = vertices.len();
     let key = format!("{:?}", vertex);
-    vertices.entry(key).or_insert((vertex, index as u16)).1
+    vertices.entry(key).or_insert((vertex, index)).1
   }
 }
 


### PR DESCRIPTION
Use usize for the vertex indices so there can be more than 65535 verticies in a Chunk

fixes #16 