### PR TITLE
Fix build and clippy actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           command: build
           toolchain: nightly
-          args:    --verbose --features=empty -Zpackage-features
+          args:    --verbose --features=empty
       - name:        Test
         uses:        actions-rs/cargo@v1
         with:
           command: test
           toolchain: nightly
-          args:    --verbose --features=empty -Zpackage-features
+          args:    --verbose --features=empty

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         toolchain: nightly
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --features=empty -Zpackage-features
+        args: --features=empty
 
   check_fmt:
     name: Rust-fmt


### PR DESCRIPTION
Upstream `cargo` has stabilized `package-features` https://github.com/rust-lang/cargo/pull/8997.

This means that we can specify features of package from the workspace without using `-Zpackage-features` or nightly.

It also breaks our build scripts.... So this PR fixes them again :)