### PR TITLE
Make bakers etc use the Chunkify traits

### DIFF
--- a/gaiku-3d/src/bakers/heightmap.rs
+++ b/gaiku-3d/src/bakers/heightmap.rs
@@ -1,11 +1,11 @@
 use std::collections::HashMap;
 
-use crate::common::{Baker, Chunk, Chunkify, Mesh};
+use crate::common::{Baker, Chunkify, Mesh};
 
 pub struct HeightMapBaker;
 
 impl Baker for HeightMapBaker {
-  fn bake(chunk: &Chunk) -> Option<Mesh> {
+  fn bake<T: Chunkify>(chunk: &T) -> Option<Mesh> {
     let mut indices = vec![];
     let mut vertices_cache = HashMap::new();
     let colors = vec![];

--- a/gaiku-3d/src/bakers/marching_cubes.rs
+++ b/gaiku-3d/src/bakers/marching_cubes.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use gaiku_common::{glam::Vec3, mint::Vector3, Baker, Chunk, Chunkify, Mesh};
+use gaiku_common::{glam::Vec3, mint::Vector3, Baker, Chunkify, Mesh};
 
 mod tables;
 
@@ -138,7 +138,7 @@ impl MarchingCubesBaker {
 }
 
 impl Baker for MarchingCubesBaker {
-  fn bake(chunk: &Chunk) -> Option<Mesh> {
+  fn bake<T: Chunkify>(chunk: &T) -> Option<Mesh> {
     let mut vertices_cache = HashMap::new();
     let mut indices = vec![];
 

--- a/gaiku-3d/src/bakers/voxel.rs
+++ b/gaiku-3d/src/bakers/voxel.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use gaiku_common::{
   mint::{Vector3, Vector4},
-  Baker, Chunk, Chunkify, Mesh,
+  Baker, Chunkify, Mesh,
 };
 
 pub struct VoxelBaker;
@@ -32,7 +32,7 @@ impl VertexData {
 
 // TODO: Optimize, don't create faces between chunks if there's a non empty voxel
 impl Baker for VoxelBaker {
-  fn bake(chunk: &Chunk) -> Option<Mesh> {
+  fn bake<T: Chunkify>(chunk: &T) -> Option<Mesh> {
     let mut indices = vec![];
     // Hash map in x, y, z coordinates to a list of verts at that coordinates
     let mut vertices: HashMap<(usize, usize, usize), Vec<VertexData>> = HashMap::new();

--- a/gaiku-3d/src/formats/gox.rs
+++ b/gaiku-3d/src/formats/gox.rs
@@ -1,4 +1,4 @@
-use gaiku_common::{Chunk, Chunkify, FileFormat};
+use gaiku_common::{Chunk, Chunkify, ChunkifyMut, FileFormat};
 
 use gox::{Block, Data, Gox, Only};
 

--- a/gaiku-common/src/data.rs
+++ b/gaiku-common/src/data.rs
@@ -1,4 +1,7 @@
 mod chunk;
 mod mesh;
 
-pub use self::{chunk::Chunk, chunk::Chunkify, chunk::ChunkifyMut, mesh::Mesh};
+pub use self::{
+  chunk::{Chunk, Chunkify, ChunkifyMut, ChunkifyNeighboured},
+  mesh::Mesh,
+};


### PR DESCRIPTION
Currently the bakers can only use the `Chunk` struct not the `Chunkify` traits, so the traits are not really working.

This PR fixes that by making the Bakers and most other things use `Chunkify` instead of `Chunk`