### PR TITLE
Boundary Relative Error and ChunkifyMut

### DIFF
--- a/gaiku-3d/src/formats/gox.rs
+++ b/gaiku-3d/src/formats/gox.rs
@@ -10,7 +10,7 @@ impl FileFormat for GoxReader {
 
   fn load<C, T>(bytes: Vec<u8>) -> Result<(Vec<C>, Option<TextureAtlas2d<T>>)>
   where
-    C: Chunkify<Self::Value> + Boxify,
+    C: Chunkify<Self::Value> + ChunkifyMut<Self::Value> + Boxify,
     T: Texturify2d,
   {
     let gox = Gox::from_bytes(bytes, vec![Only::Layers, Only::Blocks]);

--- a/gaiku-3d/src/formats/png.rs
+++ b/gaiku-3d/src/formats/png.rs
@@ -9,7 +9,7 @@ impl FileFormat for PNGReader {
 
   fn load<C, T>(bytes: Vec<u8>) -> Result<(Vec<C>, Option<TextureAtlas2d<T>>)>
   where
-    C: Chunkify<Self::Value> + Boxify,
+    C: Chunkify<Self::Value> + ChunkifyMut<Self::Value> + Boxify,
     T: Texturify2d,
   {
     let mut result = vec![];

--- a/gaiku-common/src/boundary.rs
+++ b/gaiku-common/src/boundary.rs
@@ -1,6 +1,6 @@
 use mint::Vector3;
 
-const EPSILON: f32 = 0.000001;
+const EPSILON: f32 = 1e-5;
 
 #[derive(Clone, Debug)]
 pub struct Boundary {
@@ -17,8 +17,18 @@ impl Boundary {
     Self {
       center: center.into(),
       size: size.into(),
-      start: [cx - sx - EPSILON, cy - sy - EPSILON, cz - sz - EPSILON].into(),
-      end: [cx + sx + EPSILON, cy + sy + EPSILON, cz + sz + EPSILON].into(),
+      start: [
+        cx - sx * (1. - EPSILON),
+        cy - sy * (1. - EPSILON),
+        cz - sz * (1. - EPSILON),
+      ]
+      .into(),
+      end: [
+        cx + sx * (1. + EPSILON),
+        cy + sy * (1. + EPSILON),
+        cz + sz * (1. + EPSILON),
+      ]
+      .into(),
     }
   }
 

--- a/gaiku-common/src/boundary.rs
+++ b/gaiku-common/src/boundary.rs
@@ -18,9 +18,9 @@ impl Boundary {
       center: center.into(),
       size: size.into(),
       start: [
-        cx - sx * (1. - EPSILON),
-        cy - sy * (1. - EPSILON),
-        cz - sz * (1. - EPSILON),
+        cx - sx * (1. + EPSILON),
+        cy - sy * (1. + EPSILON),
+        cz - sz * (1. + EPSILON),
       ]
       .into(),
       end: [

--- a/gaiku-common/src/chunk.rs
+++ b/gaiku-common/src/chunk.rs
@@ -7,7 +7,6 @@ pub use sparse_chunk::SparseChunk;
 pub trait Chunkify<T> {
   fn is_air(&self, x: usize, y: usize, z: usize) -> bool;
   fn get(&self, x: usize, y: usize, z: usize) -> T;
-  fn set(&mut self, x: usize, y: usize, z: usize, value: T);
 }
 
 pub trait ChunkifyMut<T> {

--- a/gaiku-common/src/chunk/chunk.rs
+++ b/gaiku-common/src/chunk/chunk.rs
@@ -18,7 +18,7 @@ pub struct Chunk {
 
 impl Chunk {
   fn index(&self, x: usize, y: usize, z: usize) -> usize {
-    x + y * self.width as usize + z * self.width as usize * self.width as usize
+    x + y * self.width as usize + z * self.width as usize * self.height as usize
   }
 
   pub fn values(&self) -> Vec<(u8, u8)> {

--- a/gaiku-common/src/chunk/chunk.rs
+++ b/gaiku-common/src/chunk/chunk.rs
@@ -1,7 +1,10 @@
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
 
-use crate::{boxify::*, chunk::Chunkify};
+use crate::{
+  boxify::*,
+  chunk::{Chunkify, ChunkifyMut},
+};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -52,7 +55,9 @@ impl Chunkify<(u8, u8)> for Chunk {
   fn get(&self, x: usize, y: usize, z: usize) -> (u8, u8) {
     self.values[self.index(x, y, z)]
   }
+}
 
+impl ChunkifyMut<(u8, u8)> for Chunk {
   fn set(&mut self, x: usize, y: usize, z: usize, value: (u8, u8)) {
     let index = self.index(x, y, z);
     self.values[index] = value;

--- a/gaiku-common/src/chunk/chunk.rs
+++ b/gaiku-common/src/chunk/chunk.rs
@@ -91,3 +91,19 @@ impl Sizable for Chunk {
     self.width
   }
 }
+
+#[cfg(test)]
+mod test {
+  use super::*;
+
+  #[test]
+  fn check_index() {
+    let chunk = Chunk::new([0.0, 0.0, 0.0], 4, 4, 4);
+    let index = chunk.index(1, 2, 3);
+    assert_eq!(index, 57);
+
+    let chunk = Chunk::new([0.0, 0.0, 0.0], 4, 5, 6);
+    let index = chunk.index(1, 2, 3);
+    assert_eq!(index, 69);
+  }
+}

--- a/gaiku-common/src/chunk/sparse_chunk.rs
+++ b/gaiku-common/src/chunk/sparse_chunk.rs
@@ -3,7 +3,10 @@ use serde::{Deserialize, Serialize};
 
 use std::collections::HashMap;
 
-use crate::{boxify::*, chunk::Chunkify};
+use crate::{
+  boxify::*,
+  chunk::{Chunkify, ChunkifyMut},
+};
 
 #[derive(Debug, Clone)]
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -21,9 +24,6 @@ impl Chunkify<u8> for SparseChunk {
 
   fn get(&self, x: usize, y: usize, z: usize) -> u8 {
     *self.data.get(&(x, y, z)).unwrap_or(&0)
-  }
-  fn set(&mut self, x: usize, y: usize, z: usize, value: u8) {
-    self.data.insert((x, y, z), value);
   }
 }
 
@@ -47,5 +47,11 @@ impl Sizable for SparseChunk {
 
   fn width(&self) -> u16 {
     self.width
+  }
+}
+
+impl ChunkifyMut<u8> for SparseChunk {
+  fn set(&mut self, x: usize, y: usize, z: usize, value: u8) {
+    self.data.insert((x, y, z), value);
   }
 }

--- a/gaiku-common/src/lib.rs
+++ b/gaiku-common/src/lib.rs
@@ -5,7 +5,7 @@ pub use mint;
 
 use crate::{
   boxify::*,
-  chunk::Chunkify,
+  chunk::{Chunkify, ChunkifyMut},
   mesh::Meshify,
   texture::{TextureAtlas2d, Texturify2d},
 };
@@ -20,7 +20,7 @@ pub mod tree;
 pub mod prelude {
   pub use crate::{
     boxify::*,
-    chunk::Chunkify,
+    chunk::{Chunkify, ChunkifyMut},
     mesh::{MeshBuilder, Meshify},
     texture::{TextureAtlas2d, Texturify2d},
     Baker, BakerOptions, FileFormat,
@@ -63,12 +63,12 @@ pub trait FileFormat {
 
   fn load<C, T>(bytes: Vec<u8>) -> Result<(Vec<C>, Option<TextureAtlas2d<T>>)>
   where
-    C: Chunkify<Self::Value> + Boxify,
+    C: Chunkify<Self::Value> + ChunkifyMut<Self::Value> + Boxify,
     T: Texturify2d;
 
   fn read<C, T>(file: &str) -> Result<(Vec<C>, Option<TextureAtlas2d<T>>)>
   where
-    C: Chunkify<Self::Value> + Boxify,
+    C: Chunkify<Self::Value> + ChunkifyMut<Self::Value> + Boxify,
     T: Texturify2d,
   {
     let bytes = read(file)?;

--- a/gaiku-common/src/mesh.rs
+++ b/gaiku-common/src/mesh.rs
@@ -241,7 +241,7 @@ impl MeshBuilderOctree {
       match &mut self.node {
         MeshBuilderOctreeNode::Leaf(leafs) => {
           let leaf_normal = if let Some(normal) = leaf.normal {
-            Some(Boundary::new(normal, [0.000001, 0.000001, 0.000001]))
+            Some(Boundary::new(normal, [1e-5, 1e-5, 1e-5]))
           } else {
             None
           };
@@ -260,7 +260,7 @@ impl MeshBuilderOctree {
             }
           }
 
-          let boundary = Boundary::new(leaf.position, [0.0, 0.0, 0.0]);
+          let boundary = Boundary::new(leaf.position, [1e-5, 1e-5, 1e-5]);
           leafs.push((leaf.clone(), boundary));
 
           if leafs.len() > self.split_at && self.bucket > 0 {


### PR DESCRIPTION
This sets up relative errors for boundary conditions and also make the code use `ChunkifyMut` which seemed to have been missed out.