### PR TITLE
Rexport common and add shorter names

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,3 +12,5 @@ pub use gaiku_format_png::*;
 
 #[cfg(feature = "gaiku_amethyst")]
 pub use gaiku_amethyst::*;
+
+pub use gaiku_common as common;


### PR DESCRIPTION
This adds gaiku_common and also adds some renaming to the reexports

So rather than doing this

```rust 
use gaiku::gaiku_common::prelude::*;
```

We can just do this

```rust
use gaiku::common::prelude::*;
```