### PR TITLE
Clippy fix (just an import)

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,10 +31,10 @@ jobs:
         with:
           command: build
           toolchain: nightly
-          args:    --verbose --features=all_features
+          args:    --verbose --all-features
       - name:        Test
         uses:        actions-rs/cargo@v1
         with:
           command: test
           toolchain: nightly
-          args:    --verbose --features=all_features
+          args:    --verbose --all-features

--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -23,7 +23,7 @@ jobs:
       with:
         toolchain: nightly
         token: ${{ secrets.GITHUB_TOKEN }}
-        args: --features=all_features
+        args: --all-features
 
   check_fmt:
     name: Rust-fmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,12 +11,6 @@ categories = ["game-engines"]
 [features]
 default = ["voxel"]
 
-all_features = [
-  "export", "serialization",
-  "heightmap", "marching_cubes", "voxel",
-  "gox", "png",
-]
-
 heightmap = ["gaiku_baker_heightmap"]
 marching_cubes = ["gaiku_baker_marching_cubes"]
 voxel = ["gaiku_baker_voxel"]

--- a/crates/gaiku_common/src/texture.rs
+++ b/crates/gaiku_common/src/texture.rs
@@ -2,9 +2,9 @@
 use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "png")]
+use crate::Result;
+#[cfg(feature = "png")]
 use std::{fs::File, io::BufWriter, path::Path};
-
-use anyhow::Result;
 
 pub(crate) const COLS: u32 = 16;
 pub(crate) const ROWS: u32 = 16;


### PR DESCRIPTION
Clippy had one issue for me which was

```rust
use anyhow::Result;
```

was unused in texture.rs

However it is only unused when not using the feature `png` so I have put it behind the feature flag. I also changed it to `crate::Result` instead so that it will be easier to change the result in future if needed, (thinking `ThisError` would be better than `AnyHow` as we can give better error messages.).

```rust
#[cfg(feature = "png")]
use crate::Result;
```

